### PR TITLE
fix/no desc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "windows-rs-mcp"
-version = "0.0.6"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [
-    { name = "Max Harley", email = "t94j0@users.noreply.github.com" }
+    { name = "Max Harley", email = "t94j0@users.noreply.github.com" },
+    { name = "Matt Hand", email = "matterpreter@users.noreply.github.com" }
 ]
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "windows-rs-mcp"
-version = "0.1.0"
+version = "0.0.6"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/src/windows_rs_mcp/__init__.py
+++ b/src/windows_rs_mcp/__init__.py
@@ -12,18 +12,7 @@ from windows_rs_mcp.docs import (
 )
 
 # Create the MCP server instance
-mcp = FastMCP(
-    "Windows Crate Docs Search",
-    description="Provides tools to search the Rust Windows crate API documentation.",
-    # Add dependencies required by the docs module
-    dependencies=["playwright"],
-    # Define return types for better schema generation
-    response_models={
-        "search_windows_api": SearchResult,
-        "ApiDocumentation": ApiDocumentation,
-        "RelatedApiFunction": RelatedApiFunction,
-    },
-)
+mcp = FastMCP("Windows Crate Docs Search")
 
 
 @mcp.tool()


### PR DESCRIPTION
FastMCP no longer supports a description. This fixes the unhandled exception when running with `uvx`.